### PR TITLE
Refactor RefreshToken model and repository

### DIFF
--- a/OnlineContestManagement/Data/Models/RefreshToken.cs
+++ b/OnlineContestManagement/Data/Models/RefreshToken.cs
@@ -1,9 +1,15 @@
 using System.ComponentModel.DataAnnotations;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace OnlineContestManagement.Data.Models
 {
     public class RefreshToken
     {
+        [BsonId]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public string _id { get; set; }
+
         [Key]
         public string Token { get; set; }
         public string UserId { get; set; }

--- a/OnlineContestManagement/Data/Repositories/RefreshTokenRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/RefreshTokenRepository.cs
@@ -1,32 +1,34 @@
 using OnlineContestManagement.Data.Models;
 using MongoDB.Driver;
+using MongoDB.Bson;
 
 namespace OnlineContestManagement.Data.Repositories
 {
-    public class RefreshTokenRepository : IRefreshTokenRepository
+  public class RefreshTokenRepository : IRefreshTokenRepository
+  {
+    private readonly IMongoCollection<RefreshToken> _refreshTokenCollection;
+
+    public RefreshTokenRepository(IMongoDatabase database)
     {
-        private readonly IMongoCollection<RefreshToken> _refreshTokenCollection;
-
-        public RefreshTokenRepository(IMongoDatabase database)
-        {
-            _refreshTokenCollection = database.GetCollection<RefreshToken>("RefreshTokens");
-        }
-
-        public async Task CreateRefreshTokenAsync(RefreshToken refreshToken)
-        {
-            await _refreshTokenCollection.InsertOneAsync(refreshToken);
-        }
-
-        public async Task<RefreshToken> GetRefreshTokenByTokenAsync(string token)
-        {
-            return await _refreshTokenCollection.Find(x => x.Token == token).FirstOrDefaultAsync();
-        }
-
-        public async Task RevokeRefreshTokenAsync(string token)
-        {
-            var filter = Builders<RefreshToken>.Filter.Eq(x => x.Token, token);
-            var update = Builders<RefreshToken>.Update.Set(x => x.IsRevoked, true);
-            await _refreshTokenCollection.UpdateOneAsync(filter, update);
-        }
+      _refreshTokenCollection = database.GetCollection<RefreshToken>("RefreshTokens");
     }
+
+    public async Task CreateRefreshTokenAsync(RefreshToken refreshToken)
+    {
+      refreshToken._id = ObjectId.GenerateNewId().ToString();
+      await _refreshTokenCollection.InsertOneAsync(refreshToken);
+    }
+
+    public async Task<RefreshToken> GetRefreshTokenByTokenAsync(string token)
+    {
+      return await _refreshTokenCollection.Find(x => x.Token == token).FirstOrDefaultAsync();
+    }
+
+    public async Task RevokeRefreshTokenAsync(string token)
+    {
+      var filter = Builders<RefreshToken>.Filter.Eq(x => x.Token, token);
+      var update = Builders<RefreshToken>.Update.Set(x => x.IsRevoked, true);
+      await _refreshTokenCollection.UpdateOneAsync(filter, update);
+    }
+  }
 }


### PR DESCRIPTION
This pull request introduces changes to integrate MongoDB with the `RefreshToken` model and repository. The most important changes include adding MongoDB attributes to the `RefreshToken` model and ensuring new tokens have a unique identifier.

### MongoDB Integration:

* [`OnlineContestManagement/Data/Models/RefreshToken.cs`](diffhunk://#diff-594815d09af30b5525c46f42ec3621bef4f9c31ab8e258bfb3ffb4ce092b7db7R2-R12): Added MongoDB attributes `[BsonId]` and `[BsonRepresentation(BsonType.ObjectId)]` to the `_id` property to mark it as the primary key and ensure it is stored as an ObjectId.

* [`OnlineContestManagement/Data/Repositories/RefreshTokenRepository.cs`](diffhunk://#diff-cbcec800200e22fc12b5023c1369cfb2ee505991bfe0ef620f240733f789407dR3): Added `MongoDB.Bson` using directive to the repository file.

* [`OnlineContestManagement/Data/Repositories/RefreshTokenRepository.cs`](diffhunk://#diff-cbcec800200e22fc12b5023c1369cfb2ee505991bfe0ef620f240733f789407dR18): Updated the `CreateRefreshTokenAsync` method to generate a new ObjectId for the `_id` property of `RefreshToken` before inserting it into the collection.