### PR TITLE
Refactor ContestController and ContestRepository

### DIFF
--- a/OnlineContestManagement/Controllers/ContestController.cs
+++ b/OnlineContestManagement/Controllers/ContestController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OnlineContestManagement.Data.Models;
@@ -118,6 +119,25 @@ namespace OnlineContestManagement.Controllers
       catch (Exception ex)
       {
         return BadRequest(new { Message = "Error searching contests", Error = ex.Message });
+      }
+    }
+
+    [HttpGet("creator/{creatorId}")]
+    public async Task<IActionResult> GetContestsByCreatorId(string creatorId)
+    {
+      if (!User.IsInRole("Admin") && User.FindFirstValue(ClaimTypes.NameIdentifier) != creatorId)
+      {
+        return Forbid();
+      }
+
+      try
+      {
+        var contests = await _contestService.GetContestsByCreatorIdAsync(creatorId);
+        return Ok(contests);
+      }
+      catch (Exception ex)
+      {
+        return BadRequest(new { Message = "Error retrieving contests by creator", Error = ex.Message });
       }
     }
   }

--- a/OnlineContestManagement/Controllers/ContestRegistrationController.cs
+++ b/OnlineContestManagement/Controllers/ContestRegistrationController.cs
@@ -17,15 +17,18 @@ namespace OnlineContestManagement.Controllers
         private readonly IContestRegistrationRepository _registrationRepository;
         private readonly IEmailService _emailService;
         private readonly IContestRegistrationService _registrationService;
+        private readonly IContestService _contestService;
 
         public ContestRegistrationController(
             IContestRegistrationRepository registrationRepository,
             IEmailService emailService,
-            IContestRegistrationService registrationService)
+            IContestRegistrationService registrationService,
+            IContestService contestService)
         {
             _registrationRepository = registrationRepository;
             _emailService = emailService;
             _registrationService = registrationService;
+            _contestService = contestService;
         }
 
         [HttpPost("{contestId}")]
@@ -84,7 +87,16 @@ namespace OnlineContestManagement.Controllers
                 return NotFound(new { Message = "No registrations found for this user." });
             }
 
-            return Ok(registrations);
+            var result = registrations.Select(async r => new
+            {
+                r.ContestId,
+                ContestDetails = await _contestService.GetContestDetailsAsync(r.ContestId),
+                r.RegistrationDate,
+                r.Status
+            }).ToList();
+
+
+            return Ok(result);
         }
     }
 }

--- a/OnlineContestManagement/Data/Repositories/ContestRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/ContestRepository.cs
@@ -98,13 +98,20 @@ namespace OnlineContestManagement.Data.Repositories
       return await _contests.Find(builder).ToListAsync();
     }
     public async Task<int> CountContestsByDateAsync(DateTime date)
-        {
-            var filter = Builders<Contest>.Filter.And(
-                Builders<Contest>.Filter.Gte(c => c.StartDate, date.Date),
-                Builders<Contest>.Filter.Lt(c => c.StartDate, date.Date.AddDays(1))
-            );
+    {
+      var filter = Builders<Contest>.Filter.And(
+          Builders<Contest>.Filter.Gte(c => c.StartDate, date.Date),
+          Builders<Contest>.Filter.Lt(c => c.StartDate, date.Date.AddDays(1))
+      );
 
-            return (int)await _contests.CountDocumentsAsync(filter);
-        }
+      return (int)await _contests.CountDocumentsAsync(filter);
     }
+
+
+
+    public async Task<List<Contest>> GetContestsByCreatorIdAsync(string creatorId)
+    {
+      return await _contests.Find(c => c.CreatorUserId == creatorId).ToListAsync();
+    }
+  }
 }

--- a/OnlineContestManagement/Data/Repositories/IContestRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/IContestRepository.cs
@@ -12,5 +12,6 @@ namespace OnlineContestManagement.Data.Repositories
     Task DeleteContestAsync(string id);
     Task<List<Contest>> SearchContestsAsync(ContestSearchFilter filter);
     Task<int> CountContestsByDateAsync(DateTime date);
-    }
+    Task<List<Contest>> GetContestsByCreatorIdAsync(string creatorId);
+  }
 }

--- a/OnlineContestManagement/Infrastructure/Services/ContestService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/ContestService.cs
@@ -113,5 +113,10 @@ namespace OnlineContestManagement.Infrastructure.Services
       var uploadResult = await _cloudinary.UploadAsync(uploadParams);
       return uploadResult.SecureUrl.ToString();
     }
+
+    public async Task<List<Contest>> GetContestsByCreatorIdAsync(string creatorId)
+    {
+      return await _contestRepository.GetContestsByCreatorIdAsync(creatorId);
+    }
   }
 }

--- a/OnlineContestManagement/Infrastructure/Services/IContestService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/IContestService.cs
@@ -11,5 +11,6 @@ namespace OnlineContestManagement.Infrastructure.Services
     Task<Contest> UpdateContestAsync(string id, UpdateContestModel model);
     Task DeleteContestAsync(string id);
     Task<List<Contest>> SearchContestsAsync(ContestSearchFilter filter);
+    Task<List<Contest>> GetContestsByCreatorIdAsync(string creatorId);
   }
 }


### PR DESCRIPTION
This pull request introduces several changes to the `OnlineContestManagement` project, focusing on adding functionality to retrieve contests by creator ID and enhancing the contest registration controller. The most important changes include adding a new endpoint in the `ContestController`, updating the `ContestRegistrationController` to include contest details, and implementing new methods in the service and repository layers.

New functionality for retrieving contests by creator ID:

* [`OnlineContestManagement/Controllers/ContestController.cs`](diffhunk://#diff-cfba72cc9d2a1d4c69a161680ee4c65e3bb241a315061d522959735c97efeae3R124-R142): Added a new endpoint `GetContestsByCreatorId` to retrieve contests by creator ID, including authorization checks.
* [`OnlineContestManagement/Data/Repositories/ContestRepository.cs`](diffhunk://#diff-2f174d9f4e4b88cb2e06d29bd0104f05ad87ca7a5ca969442b57082d5e41e7d8R109-R115): Implemented `GetContestsByCreatorIdAsync` method to query contests by creator ID.
* [`OnlineContestManagement/Infrastructure/Services/ContestService.cs`](diffhunk://#diff-a05d2776993d417169734784287aec909301d216ff670d1528a3ad2ea72ba694R116-R120): Added `GetContestsByCreatorIdAsync` method to the `ContestService` to call the corresponding repository method.
* [`OnlineContestManagement/Data/Repositories/IContestRepository.cs`](diffhunk://#diff-5d831749bf29f890953696ceedc3e483b01776eb83631429118c28699e835a84R15): Updated the `IContestRepository` interface to include the new method `GetContestsByCreatorIdAsync`.
* [`OnlineContestManagement/Infrastructure/Services/IContestService.cs`](diffhunk://#diff-71b6dd4c5df601a9724eb4ee253309cdcf902e05f55d74d7950a043010c1fb6bR14): Updated the `IContestService` interface to include the new method `GetContestsByCreatorIdAsync`.

Enhancements to contest registration controller:

* [`OnlineContestManagement/Controllers/ContestRegistrationController.cs`](diffhunk://#diff-739b15902d5462376f407557838d97a9ea0950da464cd1d55cf9b93dc226100eL87-R99): Modified the `GetContestsByUserId` method to include contest details in the response by calling the `GetContestDetailsAsync` method from the `ContestService`.
* [`OnlineContestManagement/Controllers/ContestRegistrationController.cs`](diffhunk://#diff-739b15902d5462376f407557838d97a9ea0950da464cd1d55cf9b93dc226100eR20-R31): Injected `IContestService` into the `ContestRegistrationController` to support the new functionality.

Additionally, a minor change was made to `ContestController.cs` to include the `System.Security.Claims` namespace for authorization purposes.