### PR TITLE
feat(dashboard,payments,models): Enhance contest management system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Use a base image with .NET runtime
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 80
+EXPOSE 443
+
+# Use a separate image for building the application
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["OnlineContestManagement/OnlineContestManagement.csproj", "OnlineContestManagement/"]
+RUN dotnet restore "OnlineContestManagement/OnlineContestManagement.csproj"
+COPY . .
+WORKDIR "/src/OnlineContestManagement"
+RUN dotnet build "OnlineContestManagement.csproj" -c Release -o /app/build
+
+# Copy the build output to the runtime image
+FROM build AS publish
+RUN dotnet publish "OnlineContestManagement.csproj" -c Release -o /app/publish
+
+# Final runtime image
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "OnlineContestManagement.dll"]

--- a/OnlineContestManagement/Controllers/DashboardController.cs
+++ b/OnlineContestManagement/Controllers/DashboardController.cs
@@ -65,6 +65,18 @@ namespace OnlineContestManagement.Controllers
             int totalParticipants = await _dashboardService.GetTotalParticipantsAsync();
             return Ok(totalParticipants);
         }
+        [HttpGet("monthly-revenue")]
+        public async Task<IActionResult> GetMonthlyRevenue()
+        {
+            var monthlyRevenue = await _dashboardService.GetMonthlyRevenueAsync();
+            return Ok(monthlyRevenue);
+        }
 
+        [HttpGet("featured-contests")]
+        public async Task<IActionResult> GetFeaturedContests()
+        {
+            var featuredContests = await _dashboardService.GetFeaturedContestsAsync();
+            return Ok(featuredContests);
+        }
     }
 }

--- a/OnlineContestManagement/Controllers/DashboardController.cs
+++ b/OnlineContestManagement/Controllers/DashboardController.cs
@@ -30,5 +30,41 @@ namespace OnlineContestManagement.Controllers
             var statistics = await _dashboardService.GetRegistrationStatisticsAsync();
             return Ok(statistics);
         }
+
+        [HttpGet("total-contests")]
+        public async Task<IActionResult> GetTotalContests()
+        {
+            int totalContests = await _dashboardService.GetTotalContestsAsync();
+            return Ok(totalContests);
+        }
+
+        [HttpGet("contest-participants")]
+        public async Task<IActionResult> GetContestParticipants()
+        {
+            var participants = await _dashboardService.GetContestParticipantsAsync();
+            return Ok(participants);
+        }
+
+        [HttpGet("contest-revenue")]
+        public async Task<IActionResult> GetContestRevenue()
+        {
+            var contestRevenue = await _dashboardService.GetContestRevenueAsync();
+            return Ok(new { ContestRevenue = contestRevenue });
+        }
+
+        [HttpGet("website-revenue")]
+        public async Task<IActionResult> GetWebsiteRevenue()
+        {
+            var websiteRevenue = await _dashboardService.GetWebsiteRevenueAsync();
+            return Ok(new { WebsiteRevenue = websiteRevenue });
+        }
+
+        [HttpGet("total-participants")]
+        public async Task<IActionResult> GetTotalParticipants()
+        {
+            int totalParticipants = await _dashboardService.GetTotalParticipantsAsync();
+            return Ok(totalParticipants);
+        }
+
     }
 }

--- a/OnlineContestManagement/Controllers/PaymentController.cs
+++ b/OnlineContestManagement/Controllers/PaymentController.cs
@@ -26,6 +26,10 @@ namespace OnlineContestManagement.Controllers
           return NotFound(new { Message = "Payment not found" });
         }
         var paymentLinkInformation = await _paymentService.GetPaymentInformationAsync(payment.OrderId);
+        if (paymentLinkInformation.status != "pending")
+        {
+          await _paymentService.updatePaymentStatus(contestId, userId, paymentLinkInformation.status);
+        }
         return Ok(paymentLinkInformation);
       }
       catch (Exception ex)

--- a/OnlineContestManagement/Controllers/PaymentController.cs
+++ b/OnlineContestManagement/Controllers/PaymentController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Net.payOS.Types;
 using System.Threading.Tasks;
@@ -37,5 +38,13 @@ namespace OnlineContestManagement.Controllers
         return BadRequest(new { Message = "Error retrieving payment information", Error = ex.Message });
       }
     }
+
+    [HttpPut("update-all-payment-statuses")]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> UpdateAllPaymentStatuses()
+    {
+      return await _paymentService.UpdateAllPaymentStatusesAsync();
+    }
+
   }
 }

--- a/OnlineContestManagement/Data/Models/FeaturedContest.cs
+++ b/OnlineContestManagement/Data/Models/FeaturedContest.cs
@@ -1,0 +1,11 @@
+namespace OnlineContestManagement.Data.Models
+{
+  public class FeaturedContest
+  {
+    public string Index { get; set; }
+    public string ContestId { get; set; }
+    public string Name { get; set; }
+    public int NumberOfParticipants { get; set; }
+    public string Status { get; set; }
+  }
+}

--- a/OnlineContestManagement/Data/Models/MonthlyRevenue.cs
+++ b/OnlineContestManagement/Data/Models/MonthlyRevenue.cs
@@ -1,0 +1,14 @@
+namespace OnlineContestManagement.Data.Models
+{
+  public class MonthlyRevenue
+  {
+    public RevenueId _id { get; set; }
+    public decimal TotalRevenue { get; set; }
+  }
+
+  public class RevenueId
+  {
+    public int Year { get; set; }
+    public int Month { get; set; }
+  }
+}

--- a/OnlineContestManagement/Data/Models/Payment.cs
+++ b/OnlineContestManagement/Data/Models/Payment.cs
@@ -20,5 +20,6 @@ namespace OnlineContestManagement.Data.Models
     public string ContestId { get; set; }
     public string UserId { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
   }
 }

--- a/OnlineContestManagement/Data/Repositories/ContestRegistrationRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/ContestRegistrationRepository.cs
@@ -14,8 +14,8 @@ public class ContestRegistrationRepository : IContestRegistrationRepository
     public ContestRegistrationRepository(IMongoDatabase database)
     {
         _collection = database.GetCollection<ContestRegistration>("contestRegistrations");
-        _contestCollection = database.GetCollection<Contest>("contests");
-        _userCollection = database.GetCollection<User>("users");
+        _contestCollection = database.GetCollection<Contest>("Contests");
+        _userCollection = database.GetCollection<User>("Users");
     }
 
     public async Task<bool> RegisterUserAsync(ContestRegistration registration)
@@ -97,21 +97,18 @@ public class ContestRegistrationRepository : IContestRegistrationRepository
         return (int)await _collection.CountDocumentsAsync(filter);
     }
 
-    public async Task<Dictionary<string, List<User>>> GetContestParticipantsAsync()
+    public async Task<Dictionary<string, List<ContestRegistration>>> GetContestParticipantsAsync()
     {
         var contestRegistrations = await _collection.Find(Builders<ContestRegistration>.Filter.Empty).ToListAsync();
-
-        var userIds = contestRegistrations.Select(cr => cr.UserId).Distinct().ToList();
-        var users = await _userCollection.Find(Builders<User>.Filter.In(u => u.Id, userIds)).ToListAsync();
+        Console.WriteLine($"Total registrations fetched: {contestRegistrations.Count}");
 
         return contestRegistrations
             .GroupBy(cr => cr.ContestId)
             .ToDictionary(
                 g => g.Key,
-                g => g.Select(cr => users.FirstOrDefault(u => u.Id == cr.UserId)).Where(u => u != null).ToList()
+                g => g.ToList()
             );
     }
-
     public async Task<int> GetTotalParticipantsAsync()
     {
         return (int)await _collection.CountDocumentsAsync(Builders<ContestRegistration>.Filter.Empty);

--- a/OnlineContestManagement/Data/Repositories/ContestRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/ContestRepository.cs
@@ -115,5 +115,11 @@ namespace OnlineContestManagement.Data.Repositories
     {
       return await _contests.Find(c => c.CreatorUserId == creatorId).ToListAsync();
     }
-  }
+        
+    public async Task<int> GetTotalContestsAsync()
+    {
+      return (int)await _contests.CountDocumentsAsync(Builders<Contest>.Filter.Empty);
+    }
+
+    }
 }

--- a/OnlineContestManagement/Data/Repositories/ContestRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/ContestRepository.cs
@@ -115,11 +115,13 @@ namespace OnlineContestManagement.Data.Repositories
     {
       return await _contests.Find(c => c.CreatorUserId == creatorId).ToListAsync();
     }
-        
+
     public async Task<int> GetTotalContestsAsync()
     {
       return (int)await _contests.CountDocumentsAsync(Builders<Contest>.Filter.Empty);
     }
 
-    }
+
+
+  }
 }

--- a/OnlineContestManagement/Data/Repositories/IContestRegistrationRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/IContestRegistrationRepository.cs
@@ -15,6 +15,9 @@ namespace OnlineContestManagement.Data.Repositories
         Task<int> CountRegistrationsByDateAsync(DateTime date);
         Task<Dictionary<string, List<ContestRegistration>>> GetContestParticipantsAsync();
         Task<int> GetTotalParticipantsAsync();
+        Task<List<FeaturedContest>> GetFeaturedContestsAsync(int topN = 5);
+
+
 
     }
 

--- a/OnlineContestManagement/Data/Repositories/IContestRegistrationRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/IContestRegistrationRepository.cs
@@ -13,7 +13,7 @@ namespace OnlineContestManagement.Data.Repositories
         Task<List<Contest>> GetContestsByUserIdAsync(string userId);
         Task<ContestRegistration> GetRegistrationByUserIdAndContestIdAsync(string contestId, string userId);
         Task<int> CountRegistrationsByDateAsync(DateTime date);
-        Task<Dictionary<string, List<User>>> GetContestParticipantsAsync();
+        Task<Dictionary<string, List<ContestRegistration>>> GetContestParticipantsAsync();
         Task<int> GetTotalParticipantsAsync();
 
     }

--- a/OnlineContestManagement/Data/Repositories/IContestRegistrationRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/IContestRegistrationRepository.cs
@@ -13,6 +13,9 @@ namespace OnlineContestManagement.Data.Repositories
         Task<List<Contest>> GetContestsByUserIdAsync(string userId);
         Task<ContestRegistration> GetRegistrationByUserIdAndContestIdAsync(string contestId, string userId);
         Task<int> CountRegistrationsByDateAsync(DateTime date);
+        Task<Dictionary<string, List<User>>> GetContestParticipantsAsync();
+        Task<int> GetTotalParticipantsAsync();
+
     }
 
 }

--- a/OnlineContestManagement/Data/Repositories/IContestRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/IContestRepository.cs
@@ -15,5 +15,6 @@ namespace OnlineContestManagement.Data.Repositories
     Task<List<Contest>> GetContestsByCreatorIdAsync(string creatorId);
     Task<int> GetTotalContestsAsync();
 
-    }
+
+  }
 }

--- a/OnlineContestManagement/Data/Repositories/IContestRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/IContestRepository.cs
@@ -13,5 +13,7 @@ namespace OnlineContestManagement.Data.Repositories
     Task<List<Contest>> SearchContestsAsync(ContestSearchFilter filter);
     Task<int> CountContestsByDateAsync(DateTime date);
     Task<List<Contest>> GetContestsByCreatorIdAsync(string creatorId);
-  }
+    Task<int> GetTotalContestsAsync();
+
+    }
 }

--- a/OnlineContestManagement/Data/Repositories/IPaymentRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/IPaymentRepository.cs
@@ -6,5 +6,7 @@ namespace OnlineContestManagement.Data.Repositories
   {
     Task<Payment> CreatePaymentAsync(Payment payment);
     Task<Payment> GetPaymentByContestIdAndUserIdAsync(string contestId, string userId);
-  }
+    Task<decimal> GetTotalRevenueAsync();
+
+    }
 }

--- a/OnlineContestManagement/Data/Repositories/IPaymentRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/IPaymentRepository.cs
@@ -8,6 +8,8 @@ namespace OnlineContestManagement.Data.Repositories
     Task<Payment> GetPaymentByContestIdAndUserIdAsync(string contestId, string userId);
     Task<decimal> GetTotalRevenueAsync();
     Task UpdatePaymentAsync(Payment payment);
+    Task<List<Payment>> GetAllPaymentsAsync();
+
 
   }
 }

--- a/OnlineContestManagement/Data/Repositories/IPaymentRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/IPaymentRepository.cs
@@ -10,6 +10,7 @@ namespace OnlineContestManagement.Data.Repositories
     Task UpdatePaymentAsync(Payment payment);
     Task<List<Payment>> GetAllPaymentsAsync();
 
+    Task<List<MonthlyRevenue>> GetMonthlyRevenueAsync();
 
   }
 }

--- a/OnlineContestManagement/Data/Repositories/IPaymentRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/IPaymentRepository.cs
@@ -7,6 +7,7 @@ namespace OnlineContestManagement.Data.Repositories
     Task<Payment> CreatePaymentAsync(Payment payment);
     Task<Payment> GetPaymentByContestIdAndUserIdAsync(string contestId, string userId);
     Task<decimal> GetTotalRevenueAsync();
+    Task UpdatePaymentAsync(Payment payment);
 
-    }
+  }
 }

--- a/OnlineContestManagement/Data/Repositories/PaymentRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/PaymentRepository.cs
@@ -48,5 +48,11 @@ namespace OnlineContestManagement.Data.Repositories
         {
             await _payments.ReplaceOneAsync(p => p.Id == payment.Id, payment);
         }
+
+        public async Task<List<Payment>> GetAllPaymentsAsync()
+        {
+            return await _payments.Find(FilterDefinition<Payment>.Empty).ToListAsync();
+        }
+
     }
 }

--- a/OnlineContestManagement/Data/Repositories/PaymentRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/PaymentRepository.cs
@@ -3,30 +3,49 @@ using OnlineContestManagement.Data.Models;
 
 namespace OnlineContestManagement.Data.Repositories
 {
-  public class PaymentRepository : IPaymentRepository
-  {
-    private readonly IMongoCollection<Payment> _payments;
-
-    public PaymentRepository(IMongoDatabase database)
+    public class PaymentRepository : IPaymentRepository
     {
-      _payments = database.GetCollection<Payment>("Payments");
-    }
+        private readonly IMongoCollection<Payment> _payments;
 
-    public async Task<Payment> CreatePaymentAsync(Payment payment)
-    {
-      await _payments.InsertOneAsync(payment);
-      return payment;
-    }
+        public PaymentRepository(IMongoDatabase database)
+        {
+            _payments = database?.GetCollection<Payment>("Payments")
+                        ?? throw new ArgumentNullException(nameof(database));
+        }
 
-    public async Task<Payment> GetPaymentByContestIdAndUserIdAsync(string contestId, string userId)
-    {
-      return await _payments.Find(p => p.ContestId == contestId && p.UserId == userId).FirstOrDefaultAsync();
-    }
+        public async Task<Payment> CreatePaymentAsync(Payment payment)
+        {
+            await _payments.InsertOneAsync(payment);
+            return payment;
+        }
+
+        public async Task<Payment> GetPaymentByContestIdAndUserIdAsync(string contestId, string userId)
+        {
+            return await _payments.Find(p => p.ContestId == contestId && p.UserId == userId).FirstOrDefaultAsync();
+        }
+
         public async Task<decimal> GetTotalRevenueAsync()
         {
-            var payments = await _payments.Find(p => p.ContestId != null && p.Status == "Completed").ToListAsync();
-            return payments.Sum(p => p.Price);
+            try
+            {
+                var payments = await _payments.Find(p => p.ContestId != null && p.Status == "Completed").ToListAsync();
+                if (payments == null || !payments.Any())
+                {
+                    Console.WriteLine("No payments found with ContestId and Status = Completed.");
+                    return 0;
+                }
+
+                Console.WriteLine($"Found {payments.Count} payments. Calculating total revenue.");
+                return payments.Sum(p => p.Price);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error in GetTotalRevenueAsync: {ex.Message}");
+                throw;
+            }
         }
+
+
 
     }
 }

--- a/OnlineContestManagement/Data/Repositories/PaymentRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/PaymentRepository.cs
@@ -22,6 +22,11 @@ namespace OnlineContestManagement.Data.Repositories
     {
       return await _payments.Find(p => p.ContestId == contestId && p.UserId == userId).FirstOrDefaultAsync();
     }
+        public async Task<decimal> GetTotalRevenueAsync()
+        {
+            var payments = await _payments.Find(p => p.ContestId != null && p.Status == "Completed").ToListAsync();
+            return payments.Sum(p => p.Price);
+        }
 
-  }
+    }
 }

--- a/OnlineContestManagement/Data/Repositories/PaymentRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/PaymentRepository.cs
@@ -28,7 +28,7 @@ namespace OnlineContestManagement.Data.Repositories
         {
             try
             {
-                var payments = await _payments.Find(p => p.ContestId != null && p.Status == "Completed").ToListAsync();
+                var payments = await _payments.Find(p => p.ContestId != null && p.Status.ToLower() != "cancelled").ToListAsync();
                 if (payments == null || !payments.Any())
                 {
                     Console.WriteLine("No payments found with ContestId and Status = Completed.");
@@ -44,8 +44,9 @@ namespace OnlineContestManagement.Data.Repositories
                 throw;
             }
         }
-
-
-
+        public async Task UpdatePaymentAsync(Payment payment)
+        {
+            await _payments.ReplaceOneAsync(p => p.Id == payment.Id, payment);
+        }
     }
 }

--- a/OnlineContestManagement/Infrastructure/Services/DashboardService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/DashboardService.cs
@@ -77,9 +77,19 @@ namespace OnlineContestManagement.Infrastructure.Services
 
         public async Task<decimal> GetWebsiteRevenueAsync()
         {
-            var totalRevenue = await GetContestRevenueAsync();
-            return totalRevenue * 0.3m;
+            try
+            {
+                var totalRevenue = await GetContestRevenueAsync();
+                Console.WriteLine($"Total Revenue: {totalRevenue}");
+                return totalRevenue * 0.3m;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error in GetWebsiteRevenueAsync: {ex.Message}");
+                throw;
+            }
         }
+
 
         public async Task<int> GetTotalParticipantsAsync()
         {

--- a/OnlineContestManagement/Infrastructure/Services/DashboardService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/DashboardService.cs
@@ -96,6 +96,30 @@ namespace OnlineContestManagement.Infrastructure.Services
             return await _registrationRepository.GetTotalParticipantsAsync();
         }
 
+        public async Task<List<MonthlyRevenueResponse>> GetMonthlyRevenueAsync()
+        {
+            var revenueData = await _paymentRepository.GetMonthlyRevenueAsync();
+            var currentYear = DateTime.UtcNow.Year;
+            var lastYear = currentYear - 1;
+
+            var monthlyRevenue = Enumerable.Range(1, 12).Select(month => new MonthlyRevenueResponse
+            {
+                Month = $"Tháng {month}",
+                LastYear = revenueData
+                    .Where(r => r._id.Year == lastYear && r._id.Month == month)
+                    .Sum(r => r.TotalRevenue),
+                ThisYear = revenueData
+                    .Where(r => r._id.Year == currentYear && r._id.Month == month)
+                    .Sum(r => r.TotalRevenue)
+            }).ToList();
+
+            return monthlyRevenue;
+        }
+
+        public async Task<List<FeaturedContest>> GetFeaturedContestsAsync(int topN = 5)
+        {
+            return await _registrationRepository.GetFeaturedContestsAsync(topN);
+        }
 
     }
 }

--- a/OnlineContestManagement/Infrastructure/Services/DashboardService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/DashboardService.cs
@@ -11,10 +11,11 @@ namespace OnlineContestManagement.Infrastructure.Services
         private readonly IContestRepository _contestRepository;
         private readonly IContestRegistrationRepository _registrationRepository;
         private readonly IPaymentRepository _paymentRepository;
-        public DashboardService(IContestRepository contestRepository, IContestRegistrationRepository registrationRepository)
+        public DashboardService(IContestRepository contestRepository, IContestRegistrationRepository registrationRepository, IPaymentRepository paymentRepository)
         {
             _contestRepository = contestRepository;
             _registrationRepository = registrationRepository;
+            _paymentRepository = paymentRepository;
         }
 
         public async Task<ContestStatisticsModel> GetContestStatisticsAsync()
@@ -59,7 +60,7 @@ namespace OnlineContestManagement.Infrastructure.Services
             }
             return ((double)(todayCount - yesterdayCount) / yesterdayCount) * 100;
         }
-        
+
         public async Task<int> GetTotalContestsAsync()
         {
             return await _contestRepository.GetTotalContestsAsync();
@@ -80,7 +81,6 @@ namespace OnlineContestManagement.Infrastructure.Services
             try
             {
                 var totalRevenue = await GetContestRevenueAsync();
-                Console.WriteLine($"Total Revenue: {totalRevenue}");
                 return totalRevenue * 0.3m;
             }
             catch (Exception ex)

--- a/OnlineContestManagement/Infrastructure/Services/DashboardService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/DashboardService.cs
@@ -66,7 +66,7 @@ namespace OnlineContestManagement.Infrastructure.Services
             return await _contestRepository.GetTotalContestsAsync();
         }
 
-        public async Task<Dictionary<string, List<User>>> GetContestParticipantsAsync()
+        public async Task<Dictionary<string, List<ContestRegistration>>> GetContestParticipantsAsync()
         {
             return await _registrationRepository.GetContestParticipantsAsync();
         }

--- a/OnlineContestManagement/Infrastructure/Services/DashboardService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/DashboardService.cs
@@ -1,4 +1,5 @@
-﻿using OnlineContestManagement.Data.Repositories;
+﻿using OnlineContestManagement.Data.Models;
+using OnlineContestManagement.Data.Repositories;
 using OnlineContestManagement.Models;
 using System;
 using System.Threading.Tasks;
@@ -9,7 +10,7 @@ namespace OnlineContestManagement.Infrastructure.Services
     {
         private readonly IContestRepository _contestRepository;
         private readonly IContestRegistrationRepository _registrationRepository;
-
+        private readonly IPaymentRepository _paymentRepository;
         public DashboardService(IContestRepository contestRepository, IContestRegistrationRepository registrationRepository)
         {
             _contestRepository = contestRepository;
@@ -58,5 +59,33 @@ namespace OnlineContestManagement.Infrastructure.Services
             }
             return ((double)(todayCount - yesterdayCount) / yesterdayCount) * 100;
         }
+        
+        public async Task<int> GetTotalContestsAsync()
+        {
+            return await _contestRepository.GetTotalContestsAsync();
+        }
+
+        public async Task<Dictionary<string, List<User>>> GetContestParticipantsAsync()
+        {
+            return await _registrationRepository.GetContestParticipantsAsync();
+        }
+
+        public async Task<decimal> GetContestRevenueAsync()
+        {
+            return await _paymentRepository.GetTotalRevenueAsync();
+        }
+
+        public async Task<decimal> GetWebsiteRevenueAsync()
+        {
+            var totalRevenue = await GetContestRevenueAsync();
+            return totalRevenue * 0.3m;
+        }
+
+        public async Task<int> GetTotalParticipantsAsync()
+        {
+            return await _registrationRepository.GetTotalParticipantsAsync();
+        }
+
+
     }
 }

--- a/OnlineContestManagement/Infrastructure/Services/IDashboardService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/IDashboardService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using OnlineContestManagement.Data.Models;
 using OnlineContestManagement.Models;
 
 namespace OnlineContestManagement.Infrastructure.Services
@@ -7,5 +8,11 @@ namespace OnlineContestManagement.Infrastructure.Services
     {
         Task<ContestStatisticsModel> GetContestStatisticsAsync();
         Task<RegistrationStatisticsModel> GetRegistrationStatisticsAsync();
+        Task<int> GetTotalContestsAsync();
+        Task<Dictionary<string, List<User>>> GetContestParticipantsAsync();
+        Task<decimal> GetContestRevenueAsync();
+        Task<decimal> GetWebsiteRevenueAsync();
+        Task<int> GetTotalParticipantsAsync();
+
     }
 }

--- a/OnlineContestManagement/Infrastructure/Services/IDashboardService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/IDashboardService.cs
@@ -9,7 +9,7 @@ namespace OnlineContestManagement.Infrastructure.Services
         Task<ContestStatisticsModel> GetContestStatisticsAsync();
         Task<RegistrationStatisticsModel> GetRegistrationStatisticsAsync();
         Task<int> GetTotalContestsAsync();
-        Task<Dictionary<string, List<User>>> GetContestParticipantsAsync();
+        Task<Dictionary<string, List<ContestRegistration>>> GetContestParticipantsAsync();
         Task<decimal> GetContestRevenueAsync();
         Task<decimal> GetWebsiteRevenueAsync();
         Task<int> GetTotalParticipantsAsync();

--- a/OnlineContestManagement/Infrastructure/Services/IDashboardService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/IDashboardService.cs
@@ -13,6 +13,8 @@ namespace OnlineContestManagement.Infrastructure.Services
         Task<decimal> GetContestRevenueAsync();
         Task<decimal> GetWebsiteRevenueAsync();
         Task<int> GetTotalParticipantsAsync();
+        Task<List<MonthlyRevenueResponse>> GetMonthlyRevenueAsync();
+        Task<List<FeaturedContest>> GetFeaturedContestsAsync(int topN = 5);
 
     }
 }

--- a/OnlineContestManagement/Infrastructure/Services/IPaymentService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/IPaymentService.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc;
 using Net.payOS.Types;
 using OnlineContestManagement.Data.Models;
 
@@ -8,5 +9,7 @@ public interface IPaymentService
   Task<PaymentLinkInformation> CancelPaymentAsync(int orderId);
   Task<Payment> GetPaymentByContestIdAndUserIdAsync(string contestId, string userId);
   Task updatePaymentStatus(string contestId, string userId, string status);
+  Task<IActionResult> UpdateAllPaymentStatusesAsync();
+
 
 }

--- a/OnlineContestManagement/Infrastructure/Services/IPaymentService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/IPaymentService.cs
@@ -7,5 +7,6 @@ public interface IPaymentService
   Task<PaymentLinkInformation> GetPaymentInformationAsync(int orderId);
   Task<PaymentLinkInformation> CancelPaymentAsync(int orderId);
   Task<Payment> GetPaymentByContestIdAndUserIdAsync(string contestId, string userId);
+  Task updatePaymentStatus(string contestId, string userId, string status);
 
 }

--- a/OnlineContestManagement/Infrastructure/Services/PaymentService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/PaymentService.cs
@@ -54,5 +54,13 @@ namespace OnlineContestManagement.Infrastructure.Services
     {
       return await _paymentRepository.GetPaymentByContestIdAndUserIdAsync(contestId, userId);
     }
+
+    public async Task updatePaymentStatus(string contestId, string userId, string status)
+    {
+      Payment payment = await _paymentRepository.GetPaymentByContestIdAndUserIdAsync(contestId, userId);
+      payment.Status = status.ToLower();
+      payment.UpdatedAt = DateTime.UtcNow;
+      await _paymentRepository.UpdatePaymentAsync(payment);
+    }
   }
 }

--- a/OnlineContestManagement/Infrastructure/Services/PaymentService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/PaymentService.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using OnlineContestManagement.Data.Models;
 using OnlineContestManagement.Data.Repositories;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
 
 
 namespace OnlineContestManagement.Infrastructure.Services
@@ -13,11 +15,13 @@ namespace OnlineContestManagement.Infrastructure.Services
   {
     private readonly PayOSSettings _payOSSettings;
     private readonly IPaymentRepository _paymentRepository;
+    private readonly ILogger<PaymentService> _logger;
 
-    public PaymentService(PayOSSettings payOSSettings, IPaymentRepository paymentRepository)
+    public PaymentService(PayOSSettings payOSSettings, IPaymentRepository paymentRepository, ILogger<PaymentService> logger)
     {
       _payOSSettings = payOSSettings;
       _paymentRepository = paymentRepository;
+      _logger = logger;
     }
 
 
@@ -61,6 +65,45 @@ namespace OnlineContestManagement.Infrastructure.Services
       payment.Status = status.ToLower();
       payment.UpdatedAt = DateTime.UtcNow;
       await _paymentRepository.UpdatePaymentAsync(payment);
+    }
+
+    public async Task<IActionResult> UpdateAllPaymentStatusesAsync()
+    {
+      try
+      {
+        var payments = await _paymentRepository.GetAllPaymentsAsync();
+        foreach (var payment in payments)
+        {
+          string rawResponse = string.Empty;
+          try
+          {
+            var paymentInfo = await _payOS.getPaymentLinkInformation(payment.OrderId);
+            _logger.LogInformation("PaymentLinkInformation for OrderId {OrderId}: {@PaymentInfo}", payment.OrderId, paymentInfo);
+
+            if (paymentInfo.status.ToLower() != payment.Status.ToLower())
+            {
+              payment.Status = paymentInfo.status.ToLower();
+              payment.UpdatedAt = DateTime.UtcNow;
+              await _paymentRepository.UpdatePaymentAsync(payment);
+              _logger.LogInformation("Updated payment {PaymentId} status to {Status}", payment.Id, payment.Status);
+            }
+          }
+          catch (JsonReaderException jsonEx)
+          {
+            _logger.LogError(jsonEx, "JSON Parsing Error for OrderId {OrderId}. Raw Response: {RawResponse}", payment.OrderId, rawResponse);
+          }
+          catch (Exception ex)
+          {
+            _logger.LogError(ex, "Error retrieving payment information for OrderId {OrderId}", payment.OrderId);
+          }
+        }
+        return new OkObjectResult("All payment statuses updated successfully.");
+      }
+      catch (Exception ex)
+      {
+        _logger.LogError(ex, "Error updating payment statuses.");
+        return new BadRequestObjectResult(new { Message = "Error updating payment statuses", Error = ex.Message });
+      }
     }
   }
 }

--- a/OnlineContestManagement/Models/AuthModel.cs
+++ b/OnlineContestManagement/Models/AuthModel.cs
@@ -6,13 +6,6 @@ namespace OnlineContestManagement.Models
         public string Password { get; set; }
     }
 
-    public class AuthResponse
-    {
-        public string AccessToken { get; set; }
-        public string RefreshToken { get; set; }
-        public DateTime ExpiresAt { get; set; }
-    }
-
     public class RefreshTokenRequest
     {
         public string RefreshToken { get; set; }

--- a/OnlineContestManagement/Models/FeaturedContestResponse.cs
+++ b/OnlineContestManagement/Models/FeaturedContestResponse.cs
@@ -1,0 +1,10 @@
+namespace OnlineContestManagement.Models
+{
+  public class FeaturedContestResponse
+  {
+    public int Index { get; set; }
+    public string Name { get; set; }
+    public int NumberOfParticipants { get; set; }
+    public string Status { get; set; }
+  }
+}

--- a/OnlineContestManagement/Models/MonthlyRevenueResponse.cs
+++ b/OnlineContestManagement/Models/MonthlyRevenueResponse.cs
@@ -1,0 +1,9 @@
+namespace OnlineContestManagement.Models
+{
+  public class MonthlyRevenueResponse
+  {
+    public string Month { get; set; }
+    public decimal LastYear { get; set; }
+    public decimal ThisYear { get; set; }
+  }
+}


### PR DESCRIPTION
This pull request introduces several new features and improvements to the Online Contest Management system, including enhancements to the dashboard, payment handling, and data models. The key changes are grouped into three main themes: Dockerfile setup, new API endpoints, and repository updates.

### Dockerfile Setup:
* Added a new `Dockerfile` to streamline the build and deployment process using .NET runtime and SDK images.

### New API Endpoints:
* Added multiple new endpoints in `DashboardController` to retrieve various statistics such as total contests, contest participants, contest revenue, website revenue, total participants, monthly revenue, and featured contests.
* Added a new endpoint in `PaymentController` to update all payment statuses, restricted to admin users.

### Repository Updates:
* Introduced new models `FeaturedContest` and `MonthlyRevenue` to support the new features. [[1]](diffhunk://#diff-f34a8162483caef504cc137a849a473c5cdaf83baeffde2ffe733187204f62d6R1-R11) [[2]](diffhunk://#diff-0fd3f1ce1224be99868ca624d4f1433bc0d98b6c9a9e78a7f050d22b928d9b7aR1-R14)
* Updated `Payment` model to include `UpdatedAt` timestamp.
* Enhanced `ContestRegistrationRepository` and `ContestRepository` with methods to fetch contest participants, total participants, featured contests, and total contests. [[1]](diffhunk://#diff-62775961f575096715dcfc0afcabb48e6a371aae0ce715c9bc0db8a98e91c24bR99-R172) [[2]](diffhunk://#diff-2f174d9f4e4b88cb2e06d29bd0104f05ad87ca7a5ca969442b57082d5e41e7d8R118-R125)
* Expanded `PaymentRepository` with methods to get total revenue, update payment status, fetch all payments, and retrieve monthly revenue.
* Updated `DashboardService` and `IDashboardService` to include methods for the new statistics and revenue calculations. [[1]](diffhunk://#diff-cb1a7d945c1fc049fe6826e02f73bd1313838122de5de77379be63c4b5daacb3R63-R123) [[2]](diffhunk://#diff-637c106ec3df2e285abdd2de88c26e2a30442d02045508ae5bfe48124474771fR11-R18)