### PR TITLE
Enhance Dashboard API with new contest status endpoints and update authorization policies

### DIFF
--- a/OnlineContestManagement/Controllers/DashboardController.cs
+++ b/OnlineContestManagement/Controllers/DashboardController.cs
@@ -7,7 +7,6 @@ namespace OnlineContestManagement.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    [Authorize(Policy = "AdminOnly")]
     public class DashboardController : ControllerBase
     {
         private readonly IDashboardService _dashboardService;
@@ -16,7 +15,7 @@ namespace OnlineContestManagement.Controllers
         {
             _dashboardService = dashboardService;
         }
-
+        [Authorize(Roles = "Admin")]
         [HttpGet("contest-statistics")]
         public async Task<IActionResult> GetContestStatistics()
         {
@@ -24,6 +23,7 @@ namespace OnlineContestManagement.Controllers
             return Ok(statistics);
         }
 
+        [Authorize(Roles = "Admin")]
         [HttpGet("registration-statistics")]
         public async Task<IActionResult> GetRegistrationStatistics()
         {
@@ -31,6 +31,7 @@ namespace OnlineContestManagement.Controllers
             return Ok(statistics);
         }
 
+        [Authorize(Roles = "Admin")]
         [HttpGet("total-contests")]
         public async Task<IActionResult> GetTotalContests()
         {
@@ -38,6 +39,7 @@ namespace OnlineContestManagement.Controllers
             return Ok(totalContests);
         }
 
+        [Authorize(Roles = "Admin")]
         [HttpGet("contest-participants")]
         public async Task<IActionResult> GetContestParticipants()
         {
@@ -45,6 +47,7 @@ namespace OnlineContestManagement.Controllers
             return Ok(participants);
         }
 
+        [Authorize(Roles = "Admin")]
         [HttpGet("contest-revenue")]
         public async Task<IActionResult> GetContestRevenue()
         {
@@ -52,6 +55,7 @@ namespace OnlineContestManagement.Controllers
             return Ok(new { ContestRevenue = contestRevenue });
         }
 
+        [Authorize(Roles = "Admin")]
         [HttpGet("website-revenue")]
         public async Task<IActionResult> GetWebsiteRevenue()
         {
@@ -65,6 +69,8 @@ namespace OnlineContestManagement.Controllers
             int totalParticipants = await _dashboardService.GetTotalParticipantsAsync();
             return Ok(totalParticipants);
         }
+
+        [Authorize(Roles = "Admin")]
         [HttpGet("monthly-revenue")]
         public async Task<IActionResult> GetMonthlyRevenue()
         {
@@ -72,18 +78,37 @@ namespace OnlineContestManagement.Controllers
             return Ok(monthlyRevenue);
         }
 
+        [Authorize(Roles = "Admin")]
         [HttpGet("featured-contests")]
         public async Task<IActionResult> GetFeaturedContests()
         {
             var featuredContests = await _dashboardService.GetFeaturedContestsAsync();
             return Ok(featuredContests);
         }
+
+        [Authorize(Roles = "Admin")]
         [HttpGet("quarterly-contest-counts")]
         public async Task<IActionResult> GetQuarterlyContestCounts()
         {
             var quarterlyCounts = await _dashboardService.GetQuarterlyContestDataAsync();
             return Ok(quarterlyCounts);
         }
+
+        [HttpGet("comingsoon-contests")]
+        public async Task<IActionResult> GetComingSoonContestCount()
+        {
+            int count = await _dashboardService.GetComingSoonContestCountAsync();
+            return Ok(new { ComingSoonContests = count });
+        }
+
+        [HttpGet("onboarding-contests")]
+        public async Task<IActionResult> GetOnBoardingContestCount()
+        {
+            int count = await _dashboardService.GetOnBoardingContestCountAsync();
+            return Ok(new { OnBoardingContests = count });
+        }
+
+
 
     }
 }

--- a/OnlineContestManagement/Data/Repositories/IContestRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/IContestRepository.cs
@@ -15,5 +15,7 @@ namespace OnlineContestManagement.Data.Repositories
     Task<List<Contest>> GetContestsByCreatorIdAsync(string creatorId);
     Task<int> GetTotalContestsAsync();
     Task<List<QuarterlyContestStatusCountResponse>> GetQuarterlyContestCountsAsync();
+    Task<int> GetContestCountByStatusAsync(string status);
+
   }
 }

--- a/OnlineContestManagement/Infrastructure/Services/DashboardService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/DashboardService.cs
@@ -155,5 +155,16 @@ namespace OnlineContestManagement.Infrastructure.Services
 
             return data;
         }
+
+        public async Task<int> GetComingSoonContestCountAsync()
+        {
+            return await _contestRepository.GetContestCountByStatusAsync("Sắp diễn ra");
+        }
+
+        public async Task<int> GetOnBoardingContestCountAsync()
+        {
+            return await _contestRepository.GetContestCountByStatusAsync("Đang diễn ra");
+        }
+
     }
 }

--- a/OnlineContestManagement/Infrastructure/Services/IDashboardService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/IDashboardService.cs
@@ -16,5 +16,8 @@ namespace OnlineContestManagement.Infrastructure.Services
         Task<List<MonthlyRevenueResponse>> GetMonthlyRevenueAsync();
         Task<List<FeaturedContest>> GetFeaturedContestsAsync(int topN = 5);
         Task<List<QuarterlyContestDataResponse>> GetQuarterlyContestDataAsync();
+        Task<int> GetComingSoonContestCountAsync();
+        Task<int> GetOnBoardingContestCountAsync();
+
     }
 }


### PR DESCRIPTION
This pull request includes several changes to the `DashboardController` and related services in the `OnlineContestManagement` project. The changes primarily focus on modifying authorization policies and adding new methods to handle contest statistics and counts.

Authorization policy changes:

* [`OnlineContestManagement/Controllers/DashboardController.cs`](diffhunk://#diff-342d6d42a2a659b77606b276dc289a77463bf35f4fb57bd32ada0ce939aae973L10): Replaced `[Authorize(Policy = "AdminOnly")]` with `[Authorize(Roles = "Admin")]` for individual endpoints. [[1]](diffhunk://#diff-342d6d42a2a659b77606b276dc289a77463bf35f4fb57bd32ada0ce939aae973L10) [[2]](diffhunk://#diff-342d6d42a2a659b77606b276dc289a77463bf35f4fb57bd32ada0ce939aae973L19-R58) [[3]](diffhunk://#diff-342d6d42a2a659b77606b276dc289a77463bf35f4fb57bd32ada0ce939aae973R72-R112)

New methods for contest statistics and counts:

* [`OnlineContestManagement/Data/Repositories/ContestRepository.cs`](diffhunk://#diff-2f174d9f4e4b88cb2e06d29bd0104f05ad87ca7a5ca969442b57082d5e41e7d8R218-R252): Added `GetContestCountByStatusAsync` method to retrieve contest counts based on status.
* [`OnlineContestManagement/Data/Repositories/IContestRepository.cs`](diffhunk://#diff-5d831749bf29f890953696ceedc3e483b01776eb83631429118c28699e835a84R18-R19): Updated `IContestRepository` interface to include the new `GetContestCountByStatusAsync` method.
* [`OnlineContestManagement/Infrastructure/Services/DashboardService.cs`](diffhunk://#diff-cb1a7d945c1fc049fe6826e02f73bd1313838122de5de77379be63c4b5daacb3R158-R168): Added `GetComingSoonContestCountAsync` and `GetOnBoardingContestCountAsync` methods to fetch contest counts for specific statuses.
* [`OnlineContestManagement/Infrastructure/Services/IDashboardService.cs`](diffhunk://#diff-637c106ec3df2e285abdd2de88c26e2a30442d02045508ae5bfe48124474771fR19-R21): Updated `IDashboardService` interface to include the new methods for fetching contest counts.