### PR TITLE
Refactor WithdrawFromContest method to remove contestId parameter and use model binding

### DIFF
--- a/OnlineContestManagement/Controllers/ContestRegistrationController.cs
+++ b/OnlineContestManagement/Controllers/ContestRegistrationController.cs
@@ -53,14 +53,13 @@ namespace OnlineContestManagement.Controllers
             return BadRequest(new { Message = result.Error });
         }
         [HttpPost("withdraw")]
-        public async Task<IActionResult> WithdrawFromContest(string contestId, [FromBody] WithdrawFromContestModel withdrawModel)
+        public async Task<IActionResult> WithdrawFromContest([FromBody] WithdrawFromContestModel withdrawModel)
         {
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);
             }
 
-            withdrawModel.ContestId = contestId;
 
             var result = await _registrationService.WithdrawUserFromContestAsync(withdrawModel);
             if (result)


### PR DESCRIPTION
This pull request includes a change to the `OnlineContestManagement/Controllers/ContestRegistrationController.cs` file to improve the handling of contest withdrawal requests. The most important change is the removal of the `contestId` parameter from the `WithdrawFromContest` method.

Changes in `OnlineContestManagement/Controllers/ContestRegistrationController.cs`:

* Removed the `contestId` parameter from the `WithdrawFromContest` method to simplify the method signature and rely solely on the `WithdrawFromContestModel` for the contest ID.