### PR TITLE
Remove .env file reference from project file

### DIFF
--- a/OnlineContestManagement/OnlineContestManagement.csproj
+++ b/OnlineContestManagement/OnlineContestManagement.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.9.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.2" />
-    <None Include=".env" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request includes a small but important change to the `OnlineContestManagement.csproj` file. The change removes the `.env` file from being copied to the output directory. 

* [`OnlineContestManagement/OnlineContestManagement.csproj`](diffhunk://#diff-10520df256ef8242cac1864ad8d44198cff15812afdd1704ce733a36a58ac565L26): Removed the line that included the `.env` file with the `CopyToOutputDirectory` attribute set to `PreserveNewest`.