### PR TITLE
Add contest registration status update in PaymentController and related services

### DIFF
--- a/OnlineContestManagement/Controllers/PaymentController.cs
+++ b/OnlineContestManagement/Controllers/PaymentController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Net.payOS.Types;
+using OnlineContestManagement.Infrastructure.Services;
 using System.Threading.Tasks;
 
 namespace OnlineContestManagement.Controllers
@@ -10,11 +11,14 @@ namespace OnlineContestManagement.Controllers
   public class PaymentController : ControllerBase
   {
     private readonly IPaymentService _paymentService;
+    private readonly IContestRegistrationService _contestRegistrationService;
 
-    public PaymentController(IPaymentService paymentService)
+    public PaymentController(IPaymentService paymentService, IContestRegistrationService contestRegistrationService)
     {
       _paymentService = paymentService;
+      _contestRegistrationService = contestRegistrationService;
     }
+
 
     [HttpGet("get-payment-status/{contestId}/{userId}")]
     public async Task<ActionResult<PaymentLinkInformation>> GetPaymentLinkInformation(string contestId, string userId)
@@ -30,6 +34,8 @@ namespace OnlineContestManagement.Controllers
         if (paymentLinkInformation.status != "pending")
         {
           await _paymentService.updatePaymentStatus(contestId, userId, paymentLinkInformation.status);
+          await _contestRegistrationService.UpdateRegistrationStatusAsync(contestId, userId, paymentLinkInformation.status);
+
         }
         return Ok(paymentLinkInformation);
       }

--- a/OnlineContestManagement/Data/Repositories/ContestRegistrationRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/ContestRegistrationRepository.cs
@@ -165,6 +165,13 @@ public class ContestRegistrationRepository : IContestRegistrationRepository
             return "Đã kết thúc";
     }
 
+    public async Task UpdateRegistrationAsync(ContestRegistration registration)
+    {
+        var filter = Builders<ContestRegistration>.Filter.Eq(r => r.Id, registration.Id);
+        await _collection.ReplaceOneAsync(filter, registration);
+    }
+
+
 
 
 

--- a/OnlineContestManagement/Data/Repositories/IContestRegistrationRepository.cs
+++ b/OnlineContestManagement/Data/Repositories/IContestRegistrationRepository.cs
@@ -16,6 +16,8 @@ namespace OnlineContestManagement.Data.Repositories
         Task<Dictionary<string, List<ContestRegistration>>> GetContestParticipantsAsync();
         Task<int> GetTotalParticipantsAsync();
         Task<List<FeaturedContest>> GetFeaturedContestsAsync(int topN = 5);
+        Task UpdateRegistrationAsync(ContestRegistration registration);
+
 
 
 

--- a/OnlineContestManagement/Infrastructure/Services/ContestRegistrationService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/ContestRegistrationService.cs
@@ -3,6 +3,7 @@ using OnlineContestManagement.Data.Repositories;
 using OnlineContestManagement.Models;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 
 namespace OnlineContestManagement.Infrastructure.Services
@@ -220,5 +221,19 @@ namespace OnlineContestManagement.Infrastructure.Services
         {
             return await _registrationRepository.GetRegistrationsByContestIdAsync(contestId);
         }
+
+        public async Task UpdateRegistrationStatusAsync(string contestId, string userId, string status)
+        {
+            var registration = await _registrationRepository.GetRegistrationByUserIdAndContestIdAsync(contestId, userId);
+            if (registration != null)
+            {
+                if (status.Equals("withdrawn", StringComparison.OrdinalIgnoreCase))
+                    return;
+
+                registration.Status = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(status.ToLowerInvariant());
+                await _registrationRepository.UpdateRegistrationAsync(registration);
+            }
+        }
+
     }
 }

--- a/OnlineContestManagement/Infrastructure/Services/IContestRegistrationService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/IContestRegistrationService.cs
@@ -11,6 +11,8 @@ namespace OnlineContestManagement.Infrastructure.Services
         Task<List<ContestRegistration>> GetContestsByUserIdAsync(string userId);
 
         Task<List<ContestRegistration>> GetRegistrationsByContestIdAsync(string contestId);
+        Task UpdateRegistrationStatusAsync(string contestId, string userId, string status);
+
     }
 
 }

--- a/OnlineContestManagement/Models/ContestRegistrationModel.cs
+++ b/OnlineContestManagement/Models/ContestRegistrationModel.cs
@@ -6,7 +6,6 @@ namespace OnlineContestManagement.Models
 {
     public class RegisterForContestModel
     {
-        [Required]
         public string UserId { get; set; }
 
         [Required]


### PR DESCRIPTION
This pull request introduces several changes to the `OnlineContestManagement` project, focusing on enhancing the payment and contest registration functionalities. The main updates include the addition of a new service to handle contest registration status updates and corresponding modifications in the controller and repository layers.

### Payment and Contest Registration Enhancements:

* **Controller Updates:**
  * Added `IContestRegistrationService` to `PaymentController` to manage contest registration status updates.
  * Updated the `GetPaymentLinkInformation` method to call `UpdateRegistrationStatusAsync` from the `IContestRegistrationService` when the payment status is not "pending".

* **Service Layer Updates:**
  * Implemented `UpdateRegistrationStatusAsync` in `ContestRegistrationService` to update the registration status based on the payment status.
  * Updated `IContestRegistrationService` interface to include `UpdateRegistrationStatusAsync`.

* **Repository Layer Updates:**
  * Added `UpdateRegistrationAsync` method in `ContestRegistrationRepository` to update contest registration records.
  * Updated `IContestRegistrationRepository` interface to include `UpdateRegistrationAsync`.

* **Miscellaneous:**
  * Added necessary using directives in `PaymentController.cs` and `ContestRegistrationService.cs` for the new service and functionality. [[1]](diffhunk://#diff-e8486e2543b275b65c2c7546431adc175617f4331d6e8f19bae1c5bdd2067b4dR4) [[2]](diffhunk://#diff-cb9ca4a2af19c9b119a50e61c22fb337bd2a552c98bf9193248754f37631de0bR6)

These changes enhance the system's ability to handle contest registration status updates in response to payment status changes, improving the overall functionality and user experience.