### PR TITLE
Add functionality to download contest registrations as Excel file

### DIFF
--- a/OnlineContestManagement/Controllers/ContestRegistrationController.cs
+++ b/OnlineContestManagement/Controllers/ContestRegistrationController.cs
@@ -104,5 +104,25 @@ namespace OnlineContestManagement.Controllers
             }
             return Ok(registrations);
         }
+
+        [HttpGet("{contestId}/registrations/excel")]
+        public async Task<IActionResult> DownloadRegistrationsExcel(string contestId)
+        {
+            try
+            {
+                var excelData = await _registrationService.GenerateContestRegistrationsExcelAsync(contestId);
+                var fileName = $"Contest_{contestId}_Registrations.xlsx";
+                return File(excelData, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", fileName);
+            }
+            catch (ArgumentException ex)
+            {
+                return NotFound(new { Message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { Message = "Error generating Excel file.", Error = ex.Message });
+            }
+        }
+
     }
 }

--- a/OnlineContestManagement/Infrastructure/Services/IContestRegistrationService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/IContestRegistrationService.cs
@@ -12,6 +12,7 @@ namespace OnlineContestManagement.Infrastructure.Services
 
         Task<List<ContestRegistration>> GetRegistrationsByContestIdAsync(string contestId);
         Task UpdateRegistrationStatusAsync(string contestId, string userId, string status);
+        Task<byte[]> GenerateContestRegistrationsExcelAsync(string contestId);
 
     }
 

--- a/OnlineContestManagement/OnlineContestManagement.csproj
+++ b/OnlineContestManagement/OnlineContestManagement.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ClosedXML" Version="0.104.2" />
     <PackageReference Include="CloudinaryDotNet" Version="1.26.2" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="FirebaseAdmin" Version="3.1.0" />
@@ -14,15 +15,17 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-rc.2.24474.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="MongoDB.Bson" Version="3.0.0" />
-    <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
-    <PackageReference Include="NuGet.PackageManagement" Version="6.11.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
+    <PackageReference Include="MongoDB.Bson" Version="3.1.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.1.0" />
+    <PackageReference Include="NuGet.PackageManagement" Version="6.12.1" />
     <PackageReference Include="payOS" Version="1.0.9" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.9.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.1.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
+    <RuntimeHostConfigurationOption Include="System.Drawing.EnableGdiPlus" Value="true" />
+  
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request introduces a feature to generate and download contest registrations as an Excel file. The most important changes include adding a new endpoint to trigger the download, implementing the Excel generation logic, and updating dependencies to support this feature.

### New Feature: Excel Export for Contest Registrations

* [`OnlineContestManagement/Controllers/ContestRegistrationController.cs`](diffhunk://#diff-739b15902d5462376f407557838d97a9ea0950da464cd1d55cf9b93dc226100eR107-R126): Added a new endpoint `DownloadRegistrationsExcel` to handle the download request for contest registrations in Excel format.
* [`OnlineContestManagement/Infrastructure/Services/ContestRegistrationService.cs`](diffhunk://#diff-cb9ca4a2af19c9b119a50e61c22fb337bd2a552c98bf9193248754f37631de0bR238-R336): Implemented the method `GenerateContestRegistrationsExcelAsync` to create an Excel file with contest registration data using the ClosedXML library.
* [`OnlineContestManagement/Infrastructure/Services/IContestRegistrationService.cs`](diffhunk://#diff-53216ab93a3981fc503fbe43cbb92c700d0986084cb4078e833bf4619fd3e735R15): Added the method signature for `GenerateContestRegistrationsExcelAsync` to the `IContestRegistrationService` interface.

### Dependency Updates

* [`OnlineContestManagement/OnlineContestManagement.csproj`](diffhunk://#diff-10520df256ef8242cac1864ad8d44198cff15812afdd1704ce733a36a58ac565R10-R28): Added the ClosedXML package to support Excel file creation and updated several other package versions.