### PR TITLE
Refactor email confirmation templates to use contest names instead of IDs and add template files to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN dotnet build "OnlineContestManagement.csproj" -c Release -o /app/build
 # Publish stage
 FROM build AS publish
 RUN dotnet publish "OnlineContestManagement.csproj" -c Release -o /app/publish
+COPY Templates /app/publish/Templates
 
 # Final runtime image
 FROM base AS final

--- a/OnlineContestManagement/Infrastructure/Services/ContestRegistrationService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/ContestRegistrationService.cs
@@ -122,7 +122,6 @@ namespace OnlineContestManagement.Infrastructure.Services
                     registration.UserId,
                     registration.ContestId
                 );
-
                 var result = await _registrationRepository.RegisterUserAsync(registration);
                 if (!result)
                 {
@@ -140,7 +139,7 @@ namespace OnlineContestManagement.Infrastructure.Services
 
                 try
                 {
-                    await _emailService.SendRegistrationConfirmation(registration.Email, registration.ContestId);
+                    await _emailService.SendRegistrationConfirmation(registration.Email, contest.Name);
                     _logger.LogInformation(
                         "Registration confirmation email sent to {Email} for Contest {ContestId}",
                         registration.Email,
@@ -196,10 +195,11 @@ namespace OnlineContestManagement.Infrastructure.Services
             }
 
             await _registrationRepository.WithdrawUserAsync(withdrawModel.ContestId, withdrawModel.UserId);
+            var contest = await _contestService.GetContestDetailsAsync(withdrawModel.ContestId);
 
             if (registration != null)
             {
-                await _emailService.SendWithdrawalConfirmation(registration.Email, withdrawModel.ContestId);
+                await _emailService.SendWithdrawalConfirmation(registration.Email, contest.Name);
             }
 
             return true;

--- a/OnlineContestManagement/Infrastructure/Services/EmailService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/EmailService.cs
@@ -15,7 +15,7 @@ namespace OnlineContestManagement.Infrastructure.Services
             Console.WriteLine($"SMTP FromName: {_smtpSettings.FromName}");
         }
 
-        public async Task SendRegistrationConfirmation(string to, string contestId)
+        public async Task SendRegistrationConfirmation(string to, string contestName)
         {
             if (string.IsNullOrWhiteSpace(_smtpSettings.Username))
             {
@@ -26,7 +26,7 @@ namespace OnlineContestManagement.Infrastructure.Services
             var htmlTemplate = File.ReadAllText("Templates/RegistrationConfirmationTemplate.html");
             var emailBody = htmlTemplate
                 .Replace("{{recipientName}}", "Contestant")
-                .Replace("{{contestId}}", contestId);
+                .Replace("{{contestName}}", contestName);
 
             var message = new MailMessage
             {
@@ -45,11 +45,11 @@ namespace OnlineContestManagement.Infrastructure.Services
             }
         }
 
-        public async Task SendWithdrawalConfirmation(string to, string contestId)
+        public async Task SendWithdrawalConfirmation(string to, string contestName)
         {
             var htmlTemplate = File.ReadAllText("Templates/WithdrawalConfirmationTemplate.html");
             var emailBody = htmlTemplate
-            .Replace("{{contestId}}", contestId)
+            .Replace("{{contestName}}", contestName)
             .Replace("{{recipientName}}", "Contestant");
             Console.WriteLine("Sending withdrawal confirmation email to " + to);
             var message = new MailMessage

--- a/OnlineContestManagement/Infrastructure/Services/IEmailService.cs
+++ b/OnlineContestManagement/Infrastructure/Services/IEmailService.cs
@@ -2,8 +2,8 @@
 {
     public interface IEmailService
     {
-        Task SendRegistrationConfirmation(string email, string contestId);
-        Task SendWithdrawalConfirmation(string email, string contestId);
+        Task SendRegistrationConfirmation(string email, string contestName);
+        Task SendWithdrawalConfirmation(string email, string contestName);
         Task SendContestUpdateNotification(string email, string orgName, string contestName, string updateType);
         Task SendResetPasswordEmail(string email, string resetToken);
     }

--- a/OnlineContestManagement/Templates/RegistrationConfirmationTemplate.html
+++ b/OnlineContestManagement/Templates/RegistrationConfirmationTemplate.html
@@ -67,8 +67,8 @@
     <div class="main">
       <h1>Registration Confirmation</h1>
       <p>Dear {{recipientName}},</p>
-      <p>We are thrilled to confirm your registration for the contest with ID <span
-          class="contest-id">{{contestId}}</span>.</p>
+      <p>We are thrilled to confirm your registration for the contest named <span
+          class="contest-id">{{contestName}}</span>.</p>
       <p>Please make a note of your contest details and ensure you check your email regularly for updates.</p>
       <div class="note">
         <p>If you have any questions or need assistance, feel free to contact us at <a

--- a/OnlineContestManagement/Templates/WithdrawalConfirmationTemplate.html
+++ b/OnlineContestManagement/Templates/WithdrawalConfirmationTemplate.html
@@ -72,8 +72,8 @@
     <div class="main">
       <h1>Withdrawal Confirmation</h1>
       <p>Dear {{recipientName}},</p>
-      <p>This is to confirm that you have successfully withdrawn from the contest with ID
-        <span class="contest-id">{{contestId}}</span>.
+      <p>This is to confirm that you have successfully withdrawn from the contest named
+        <span class="contest-id">{{contestName}}</span>.
       </p>
       <p>We’re sorry to see you go, but we hope to see you participating in our future contests!</p>
       <div class="note">


### PR DESCRIPTION
This pull request includes several changes to improve the contest registration and withdrawal email notifications by using the contest name instead of the contest ID. Additionally, there are some minor changes to the Dockerfile and the `ContestRegistrationService`.

Improvements to email notifications:

* [`OnlineContestManagement/Infrastructure/Services/EmailService.cs`](diffhunk://#diff-92b46fcbeb3230818a447157f5c30789b6cf6e0adab6bd1ab917ffb426906eb4L18-R18): Updated methods `SendRegistrationConfirmation` and `SendWithdrawalConfirmation` to use `contestName` instead of `contestId`. [[1]](diffhunk://#diff-92b46fcbeb3230818a447157f5c30789b6cf6e0adab6bd1ab917ffb426906eb4L18-R18) [[2]](diffhunk://#diff-92b46fcbeb3230818a447157f5c30789b6cf6e0adab6bd1ab917ffb426906eb4L29-R29) [[3]](diffhunk://#diff-92b46fcbeb3230818a447157f5c30789b6cf6e0adab6bd1ab917ffb426906eb4L48-R52)
* [`OnlineContestManagement/Infrastructure/Services/IEmailService.cs`](diffhunk://#diff-eb076bc25ddf91c350bff05794c300d00d3abc2376782ae78c9d4b8a83eab1d0L5-R6): Updated method signatures to use `contestName` instead of `contestId`.
* [`OnlineContestManagement/Templates/RegistrationConfirmationTemplate.html`](diffhunk://#diff-e1c3fde0e16fc0ac3d9a02e097fd94f412cbed300499ea920a9cfe190948ec9aL70-R71): Updated template to use `contestName` instead of `contestId`.
* [`OnlineContestManagement/Templates/WithdrawalConfirmationTemplate.html`](diffhunk://#diff-36425838f8dbd836b50385fc91266e1ceed961ccc1e7b1d4b4f4626238f30a77L75-R76): Updated template to use `contestName` instead of `contestId`.

Other changes:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R19): Added a step to copy the `Templates` folder to the publish directory.
* [`OnlineContestManagement/Infrastructure/Services/ContestRegistrationService.cs`](diffhunk://#diff-cb9ca4a2af19c9b119a50e61c22fb337bd2a552c98bf9193248754f37631de0bL143-R142): Updated email sending logic to use contest name and added a call to get contest details during user withdrawal. [[1]](diffhunk://#diff-cb9ca4a2af19c9b119a50e61c22fb337bd2a552c98bf9193248754f37631de0bL143-R142) [[2]](diffhunk://#diff-cb9ca4a2af19c9b119a50e61c22fb337bd2a552c98bf9193248754f37631de0bR198-R202)